### PR TITLE
Rename duplicate Conditional filters heading title

### DIFF
--- a/documentation/asciidoc/computers/config_txt/what_is_config_txt.adoc
+++ b/documentation/asciidoc/computers/config_txt/what_is_config_txt.adoc
@@ -46,6 +46,6 @@ For example, adding the line `include extraconfig.txt` to `config.txt` will incl
 
 *Include directives are not supported by bootcode.bin or the EEPROM bootloader*
 
-==== Conditional Filters
+==== Conditional Filtering
 
 Conditional filters are covered in the xref:config_txt.adoc#conditional-filters[conditionals section].


### PR DESCRIPTION
Rename the duplicate Conditional filters heading title under "Advanced Features", which was getting in the way of jumping into the desired section.